### PR TITLE
Improved data-set deletion, and new SQL procs

### DIFF
--- a/data-store/src/main/java/ca/gc/triagency/datastore/controller/DatasetController.java
+++ b/data-store/src/main/java/ca/gc/triagency/datastore/controller/DatasetController.java
@@ -49,7 +49,19 @@ public class DatasetController {
 		model.addAttribute("datasets", datasetService.getAllDatasets());
 		return "datasets/home";
 	}
-
+	
+	@RequestMapping(value = "/cleanDatasets", method = RequestMethod.GET)
+	public String cleanDatasets() {
+		datasetService.deleteMarkedDatasets();
+		return "datasets/home";
+	}
+	
+	@RequestMapping(value = "/deleteDataset", method = RequestMethod.GET)
+	public String deleteDataset(@RequestParam Long id) {
+		datasetService.deleteDatasetById(id);
+		return "datasets/home";
+	}
+	
 	@GetMapping(value = "/createAwardDataset")
 	public String createAwardDatasetSelectFile(@RequestParam long id, Model model) {
 		model.addAttribute("parentDataset", datasetService.getDataset(id));

--- a/data-store/src/main/java/ca/gc/triagency/datastore/jdbc/DatasetDAO.java
+++ b/data-store/src/main/java/ca/gc/triagency/datastore/jdbc/DatasetDAO.java
@@ -1,13 +1,11 @@
 package ca.gc.triagency.datastore.jdbc;
 
-import java.sql.SQLException;
 import java.util.List;
 import javax.sql.DataSource;
 
 import ca.gc.triagency.datastore.model.Dataset;
 import ca.gc.triagency.datastore.model.file.ApplyDatasetRow;
 import ca.gc.triagency.datastore.model.file.AwardDatasetRow;
-
 
 public interface DatasetDAO{
 	
@@ -21,7 +19,9 @@ public interface DatasetDAO{
 	
 	public void insertAwardBatch(List<AwardDatasetRow> awards);
 	
+	public void deleteToDelete();
+	
 	public void deleteDatasetById(Long id);
 	
-	public List<Dataset> getDatasetsToDelete();
+//	public List<Long> getDatasetsToDelete();
 }

--- a/data-store/src/main/java/ca/gc/triagency/datastore/jdbc/DatasetRowMapper.java
+++ b/data-store/src/main/java/ca/gc/triagency/datastore/jdbc/DatasetRowMapper.java
@@ -1,0 +1,39 @@
+package ca.gc.triagency.datastore.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Service;
+
+import ca.gc.triagency.datastore.model.Dataset;
+import ca.gc.triagency.datastore.model.Dataset.DatasetStatus;
+import ca.gc.triagency.datastore.model.Dataset.DatasetType;
+import ca.gc.triagency.datastore.model.DatasetConfiguration;
+import ca.gc.triagency.datastore.service.DatasetService;
+
+@Service
+public class DatasetRowMapper implements RowMapper<Dataset> {
+	
+	DatasetService datasetService;
+	
+	@Override
+	public Dataset mapRow(ResultSet rs, int rowNum) throws SQLException {
+		Dataset dataset = new Dataset();
+		
+		dataset.setId(rs.getLong("id"));
+		dataset.setFilename(rs.getString("filename"));
+		dataset.setParentDataset(datasetService.getDataset(rs.getLong("parent_dataset_id")));
+		dataset.setDatasetConfiguration(datasetService.getDatasetConfiguration(rs.getLong("dataset_configuration_id")));
+		dataset.setCreateDateTime(LocalDateTime.of(rs.getDate("create_date_time").toLocalDate(), rs.getTime("create_date_time").toLocalTime()));
+		dataset.setUpdateDateTime(LocalDateTime.of(rs.getDate("update_date_time").toLocalDate(), rs.getTime("update_date_time").toLocalTime()));
+		dataset.setTotalRecords(rs.getLong("total_records"));
+		dataset.setCurrentRow(rs.getLong("current_row"));
+		dataset.setDatasetStatus(DatasetStatus.valueOf(rs.getString("dataset_status")));
+		dataset.setDatasetType(DatasetType.valueOf(rs.getString("dataset_type")));
+		
+		return dataset;
+	}
+	
+}

--- a/data-store/src/main/java/ca/gc/triagency/datastore/model/Dataset.java
+++ b/data-store/src/main/java/ca/gc/triagency/datastore/model/Dataset.java
@@ -17,14 +17,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 public class Dataset {
-	public DatasetStatus getDatasetStatus() {
-		return datasetStatus;
-	}
-
-	public void setDatasetStatus(DatasetStatus datasetStatus) {
-		this.datasetStatus = datasetStatus;
-	}
-
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	private Long id;
@@ -68,6 +61,14 @@ public class Dataset {
 		APPLICATIONS, AWARDS, PAYMENTS
 	}
 
+	public DatasetStatus getDatasetStatus() {
+		return datasetStatus;
+	}
+
+	public void setDatasetStatus(DatasetStatus datasetStatus) {
+		this.datasetStatus = datasetStatus;
+	}
+	
 	public String getFilename() {
 		return filename;
 	}
@@ -110,6 +111,10 @@ public class Dataset {
 
 	public Long getId() {
 		return id;
+	}
+	
+	public void setId(Long id) {
+		this.id = id;
 	}
 	
 	public DatasetConfiguration getDatasetConfiguration() {

--- a/data-store/src/main/java/ca/gc/triagency/datastore/service/DatasetService.java
+++ b/data-store/src/main/java/ca/gc/triagency/datastore/service/DatasetService.java
@@ -69,7 +69,7 @@ public interface DatasetService {
 	@Async
 	public void uploadAwardData(Dataset dataset);
 	
-	public void deleteDataset(Dataset dataset);
+	public void deleteDatasetById(Long id);
 	
 	public void deleteMarkedDatasets();
 }

--- a/data-store/src/main/java/ca/gc/triagency/datastore/service/impl/DatasetServiceImpl.java
+++ b/data-store/src/main/java/ca/gc/triagency/datastore/service/impl/DatasetServiceImpl.java
@@ -753,17 +753,11 @@ public class DatasetServiceImpl implements DatasetService {
 						datasetRepo.save(set);
 					}
 				} else if (set.getDatasetType() == DatasetType.AWARDS) {
-					if (set.getParentDataset() != null && set.getParentDataset().getDatasetConfiguration().getId() == ds.getDatasetConfiguration().getId()) {
+					if (set.getParentDataset() != null && set.getParentDataset().getId() != ds.getId() && set.getParentDataset().getDatasetConfiguration().getId() == ds.getDatasetConfiguration().getId()) {
 						set.setDatasetStatus(DatasetStatus.TO_DELETE);
 						datasetRepo.save(set);
 					}
 				} 
-//				else if (set.getDatasetType() == DatasetType.PAYMENTS) {
-//					if (set.getParentDataset() != null && set.getParentDataset().getParentDataset() != null && set.getParentDataset().getParentDataset().getDatasetConfiguration().getId() == ds.getDatasetConfiguration().getId()) {
-//						set.setDatasetStatus(DatasetStatus.TO_DELETE);
-//						datasetRepo.save(set);
-//					}
-//				}
 			}
 			ds.setDatasetStatus(DatasetStatus.APPROVED);
 			datasetRepo.save(ds);

--- a/data-store/src/main/resources/delete_dataset_by_id.sql
+++ b/data-store/src/main/resources/delete_dataset_by_id.sql
@@ -1,0 +1,61 @@
+CREATE DEFINER=`root`@`localhost` PROCEDURE `delete_dataset_by_id`(
+IN in_id BIGINT)
+BEGIN
+	DECLARE ds_type VARCHAR(255);
+    
+    SELECT dataset_type INTO ds_type
+    FROM dataset
+    WHERE id = in_id
+    ;
+    
+    DELETE FROM dataset
+    WHERE id = in_id
+    ;
+    
+    IF ds_type = "APPLICATIONS" THEN
+		DELETE FROM master_dataset 
+		WHERE dataset_id = in_id
+		;
+		
+		DELETE FROM dataset_app_registration_role
+		WHERE id IN( SELECT registration_role_id
+					 FROM dataset_application_registration
+					 WHERE dataset_application_id IN( SELECT id
+													  FROM dataset_application
+													  WHERE dataset_id = in_id
+													  )
+					 )
+		;
+		
+		DELETE FROM dataset_application_registration 
+		WHERE dataset_application_id IN( SELECT id
+										 FROM dataset_application
+										 WHERE dataset_id = in_id
+										 )
+		;
+		
+		DELETE FROM dataset_application 
+		WHERE dataset_id = in_id
+		;
+		
+		DELETE FROM dataset_program
+		WHERE dataset_id = in_id
+		;
+		
+		DELETE FROM dataset_organization
+		WHERE dataset_id = in_id
+		;
+		
+--  	DELETE FROM dataset_award
+--  	WHERE dataset_application_id IN( SELECT id
+-- 										 FROM dataset_application
+--      	                             WHERE dataset_id = in_id
+-- 	                                     )
+--  	;									 
+    ELSEIF ds_type = "AWARDS" THEN
+		DELETE FROM award_dataset 
+		WHERE dataset_id = in_id
+		;
+        
+	END IF;
+END

--- a/data-store/src/main/resources/delete_datasets_to_delete.sql
+++ b/data-store/src/main/resources/delete_datasets_to_delete.sql
@@ -1,0 +1,84 @@
+CREATE DEFINER=`root`@`localhost` PROCEDURE `delete_datasets_to_delete`()
+BEGIN
+
+DECLARE v_id BIGINT DEFAULT 0;
+DECLARE v_finished INTEGER DEFAULT 0;
+DECLARE v_ds_type VARCHAR(100) DEFAULT "";
+
+DECLARE id_cursor CURSOR FOR
+	SELECT id FROM dataset
+	WHERE dataset_status = "TO_DELETE";
+
+DECLARE CONTINUE HANDLER FOR
+	NOT FOUND SET v_finished = 1;
+
+OPEN id_cursor;
+
+delete_to_delete: LOOP
+
+	FETCH id_cursor INTO v_id;
+
+	IF v_finished = 1 THEN
+		LEAVE delete_to_delete;
+	END IF;
+
+	SELECT dataset_type INTO v_ds_type
+		FROM dataset
+		WHERE id = v_id;
+
+	DELETE FROM dataset
+		WHERE id = v_id
+		;
+
+	IF v_ds_type = "APPLICATIONS" THEN
+		DELETE FROM master_dataset 
+			WHERE dataset_id = v_id
+			;
+		
+		DELETE FROM dataset_app_registration_role
+			WHERE id IN( SELECT registration_role_id
+							FROM dataset_application_registration
+							WHERE dataset_application_id IN( SELECT id
+																FROM dataset_application
+																WHERE dataset_id = v_id
+																)
+							)
+			;
+		
+		DELETE FROM dataset_application_registration 
+			WHERE dataset_application_id IN( SELECT id
+												FROM dataset_application
+												WHERE dataset_id = v_id
+												)
+			;
+		
+		DELETE FROM dataset_application 
+			WHERE dataset_id = v_id
+			;
+		
+		DELETE FROM dataset_program
+			WHERE dataset_id = v_id
+			;
+		
+		DELETE FROM dataset_organization
+			WHERE dataset_id = v_id
+			;
+		
+	--  	DELETE FROM dataset_award
+	--  		WHERE dataset_application_id IN( SELECT id
+	-- 											 	FROM dataset_application
+	--      	                             	 	WHERE dataset_id = v_id
+	-- 	                                     	 	)
+	--  	;									 
+	ELSEIF v_ds_type = "AWARDS" THEN
+		DELETE FROM award_dataset 
+			WHERE dataset_id = v_id
+			;
+		
+	END IF;
+
+END LOOP;
+
+CLOSE id_cursor;
+
+END

--- a/data-store/src/main/resources/static/js/datasetsTable.js
+++ b/data-store/src/main/resources/static/js/datasetsTable.js
@@ -18,18 +18,23 @@ $(document).ready( function () {
 		 var data = table.row( this ).data();
 		 window.location='viewDataset?id=' + data.id;
 	 });
-	 
+
+	 // for updating the current row and status information in the table.
 	 var intervalID = setInterval( function () {
 		 
-//		 var totalContainsZero = table.column(3).data().toArray().includes(0);
-//		 var isNormalizing = table.column(2).data().toArray().includes("NORMALIZING")
-//		 if(!totalContainsZero && !isNormalizing){
-//			 clearInterval(intervalID);
+		 var isUploading = table.column(2).data().toArray().includes("UPLOADING");
+		 var isNormalizing = table.column(2).data().toArray().includes("NORMALIZING");
+		 var isCreating = table.column(2).data().toArray().includes("CREATED");
+		 
+		 // clears the interval only if it's not in the process of uploading a dataset
+		 if(!isUploading && !isNormalizing && !isCreating) {
+			 clearInterval(intervalID);
 //			 alert('Interval Cleared');
-//		 }else{
+		 }else{
 			 table.ajax.reload(null, false);
-//		 }
+		 }
 		
-	 }, 500); 
+	 }, 300); 
 	 
 });
+

--- a/data-store/src/main/resources/templates/datasets/home.html
+++ b/data-store/src/main/resources/templates/datasets/home.html
@@ -37,6 +37,8 @@
 			        </tfoot>
 			    </table>
 		        <p>Click <a th:href="createDataset">here</a> to create a new data-set</p>
+		       <!-- <input id="cleanButton" type="button" class="btn btn-primary" value="Clean Datasets" > -->
+		       	<p><a class="btn btn-primary" th:href="@{cleanDatasets}">Clean Datasets</a></p>
 			</div>
 			<div class="col-sm-2"></div>
 

--- a/data-store/src/main/resources/templates/datasets/viewDataset.html
+++ b/data-store/src/main/resources/templates/datasets/viewDataset.html
@@ -38,6 +38,7 @@
 			<div class="col-sm-2 col-form-label" th:utext="#{form.currentRecord}">Current Record</div>
 			<div class="col-sm-10" th:text="${dataset.currentRow}"></div>
 		</div>
+		<p><a class="btn btn-primary" th:href="@{deleteDataset(id=${dataset.id})}">Delete Dataset</a></p>
 		
 		<div th:if="${#strings.equals(dataset.datasetType, 'APPLICATIONS')}">
 			<div class="form-group row">


### PR DESCRIPTION
In order for deletion to work, two new procedures need to be created in mysql; the scripts for those are included and are called "delete_dataset_by_id" and "delete_datasets_to_delete". The first one is used to delete a single data-set using a button on the view data-set page (after clicking on a data-set in the table). The second one deletes all the datasets marked "TO_DELETE" using a button on the main datasets page labeled "Clean Datasets". 